### PR TITLE
Add Multi-Template Matching plugin

### DIFF
--- a/site/plugins.json
+++ b/site/plugins.json
@@ -85,6 +85,12 @@
             "imgUrl": "https://sjc1.discourse-cdn.com/business4/uploads/imagej/original/3X/5/6/56b924bc527c4b18245f501e8f9c584360c4756e.png"
         },
         {
+            "name": "Multi-Template Matching",
+            "description": "Objects-recognition using user-provided template(s)",
+            "link": "https://imagej.net/Multi-Template_Matching",
+            "imgUrl": "https://imagej.net/_images/1/1b/Multi-Template-Matching-MontageGUI.png"
+        },
+        {
             "name": "SciView",
             "description": "3D visualization and virtual reality capabilities for images and meshes.",
             "link": "https://imagej.net/SciView",


### PR DESCRIPTION
Following the forum [thread ](https://forum.image.sc/t/which-fiji-plugins-should-be-featured-on-the-front-page/25168/51).

Multi-Template Matching is one of the few plugin for object detection. And it is easy to use (compared to training a machine for instance).